### PR TITLE
Add "unknown" as device type

### DIFF
--- a/indi-mqtt.py
+++ b/indi-mqtt.py
@@ -202,6 +202,8 @@ def strDeviceType(s):
 		return "SPECTROGRAPH"
 	elif s & (1 << 15):
 		return "AUX"
+	else:
+		return "UNKNOWN"
 
 def shutdown():
 	indiclient.disconnectServer()


### PR DESCRIPTION
Some devices (e.g. Astroberry System) do not seem to provide a device type, hence `strDeviceType` ends up as `null` and is not published to the broker.